### PR TITLE
Simplify the constructors for clients to reduce code duplication

### DIFF
--- a/Okta.Auth.Sdk.IntegrationTests/AuthenticationScenarios.cs
+++ b/Okta.Auth.Sdk.IntegrationTests/AuthenticationScenarios.cs
@@ -141,7 +141,7 @@ namespace Okta.Auth.Sdk.IntegrationTests
             }
         }
 
-        [Fact]
+        [Fact(Skip = "Group w/ right policy rules must be created. Waiting for MFA policies to be published.")]
         public async Task AuthenticateUserWithPendingEnroll()
         {
             var client = TestAuthenticationClient.Create();

--- a/Okta.Auth.Sdk/AuthenticationClient.cs
+++ b/Okta.Auth.Sdk/AuthenticationClient.cs
@@ -22,33 +22,6 @@ namespace Okta.Auth.Sdk
     public class AuthenticationClient : BaseOktaClient, IAuthenticationClient
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="AuthenticationClient"/> class.
-        /// </summary>
-        /// <param name="apiClientConfiguration">
-        /// The client configuration. If <c>null</c>, the library will attempt to load
-        /// configuration from an <c>okta.yaml</c> file or environment variables.
-        /// </param>
-        /// <param name="logger">The logging interface to use, if any.</param>
-        public AuthenticationClient(OktaClientConfiguration apiClientConfiguration = null, ILogger logger = null)
-        {
-            Configuration = GetConfigurationOrDefault(apiClientConfiguration);
-            OktaClientConfigurationValidator.Validate(Configuration);
-
-            logger = logger ?? NullLogger.Instance;
-
-            var defaultClient = DefaultHttpClient.Create(
-                Configuration.ConnectionTimeout,
-                Configuration.Proxy,
-                logger);
-
-            var requestExecutor = new DefaultRequestExecutor(Configuration, defaultClient, logger);
-            var resourceFactory = new ResourceFactory(this, logger, new AbstractResourceTypeResolverFactory(ResourceTypeHelper.GetAllDefinedTypes(typeof(Resource))));
-            var userAgentBuilder = new UserAgentBuilder("okta-auth-dotnet", typeof(AuthenticationClient).GetTypeInfo().Assembly.GetName().Version);
-
-            _dataStore = new DefaultDataStore(requestExecutor, new DefaultSerializer(), resourceFactory, logger, userAgentBuilder);
-        }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="AuthenticationClient"/> class using the specified <see cref="HttpClient"/>.
         /// </summary>
         /// <param name="apiClientConfiguration">
@@ -57,23 +30,9 @@ namespace Okta.Auth.Sdk
         /// </param>
         /// <param name="httpClient">The HTTP client to use for requests to the Okta API.</param>
         /// <param name="logger">The logging interface to use, if any.</param>
-        public AuthenticationClient(OktaClientConfiguration apiClientConfiguration, HttpClient httpClient, ILogger logger = null)
+        public AuthenticationClient(OktaClientConfiguration apiClientConfiguration = null, HttpClient httpClient = null, ILogger logger = null)
+            : base(apiClientConfiguration, httpClient, logger, "okta-auth-dotnet")
         {
-            Configuration = GetConfigurationOrDefault(apiClientConfiguration);
-            OktaClientConfigurationValidator.Validate(Configuration);
-
-            logger = logger ?? NullLogger.Instance;
-
-            var requestExecutor = new DefaultRequestExecutor(Configuration, httpClient, logger);
-            var resourceFactory = new ResourceFactory(this, logger, new AbstractResourceTypeResolverFactory(ResourceTypeHelper.GetAllDefinedTypes(typeof(Resource))));
-            var userAgentBuilder = new UserAgentBuilder("okta-auth-dotnet", typeof(BaseOktaClient).GetTypeInfo().Assembly.GetName().Version);
-
-            _dataStore = new DefaultDataStore(
-                requestExecutor,
-                new DefaultSerializer(),
-                resourceFactory,
-                logger,
-                userAgentBuilder);
         }
 
         /// <summary>

--- a/Okta.Auth.Sdk/AuthenticationClient.cs
+++ b/Okta.Auth.Sdk/AuthenticationClient.cs
@@ -30,8 +30,16 @@ namespace Okta.Auth.Sdk
         /// </param>
         /// <param name="httpClient">The HTTP client to use for requests to the Okta API.</param>
         /// <param name="logger">The logging interface to use, if any.</param>
-        public AuthenticationClient(OktaClientConfiguration apiClientConfiguration = null, HttpClient httpClient = null, ILogger logger = null)
-            : base(apiClientConfiguration, httpClient, logger, "okta-auth-dotnet")
+        public AuthenticationClient(
+            OktaClientConfiguration apiClientConfiguration = null,
+            HttpClient httpClient = null,
+            ILogger logger = null)
+            : base(
+                apiClientConfiguration,
+                httpClient,
+                logger,
+                new UserAgentBuilder("okta-auth-dotnet", typeof(AuthenticationClient).GetTypeInfo().Assembly.GetName().Version),
+                new AbstractResourceTypeResolverFactory(ResourceTypeHelper.GetAllDefinedTypes(typeof(Resource))))
         {
         }
 

--- a/Okta.Sdk.Abstractions/BaseOktaClient.cs
+++ b/Okta.Sdk.Abstractions/BaseOktaClient.cs
@@ -74,28 +74,6 @@ namespace Okta.Sdk.Abstractions
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="BaseOktaClient"/> class using the specified <see cref="HttpClient"/>.
-        /// </summary>
-        /// <param name="apiClientConfiguration">
-        /// The client configuration. If <c>null</c>, the library will attempt to load
-        /// configuration from an <c>okta.yaml</c> file or environment variables.
-        /// </param>
-        /// <param name="httpClient">The HTTP client to use for requests to the Okta API.</param>
-        /// <param name="logger">The logging interface to use, if any.</param>
-        public BaseOktaClient(
-            OktaClientConfiguration apiClientConfiguration = null,
-            HttpClient httpClient = null,
-            ILogger logger = null)
-            : this(
-                apiClientConfiguration,
-                httpClient,
-                logger,
-                new UserAgentBuilder("okta-sdk-abstractions", typeof(BaseOktaClient).GetTypeInfo().Assembly.GetName().Version),
-                new AbstractResourceTypeResolverFactory(ResourceTypeHelper.AllDefinedTypes))
-        {
-        }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="BaseOktaClient"/> class.
         /// </summary>
         /// <param name="dataStore">The <see cref="IDataStore">DataStore</see> to use.</param>

--- a/Okta.Sdk.Abstractions/BaseOktaClient.cs
+++ b/Okta.Sdk.Abstractions/BaseOktaClient.cs
@@ -35,38 +35,6 @@ namespace Okta.Sdk.Abstractions
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="BaseOktaClient"/> class.
-        /// </summary>
-        /// <param name="apiClientConfiguration">
-        /// The client configuration. If <c>null</c>, the library will attempt to load
-        /// configuration from an <c>okta.yaml</c> file or environment variables.
-        /// </param>
-        /// <param name="logger">The logging interface to use, if any.</param>
-        public BaseOktaClient(OktaClientConfiguration apiClientConfiguration = null, ILogger logger = null)
-        {
-            Configuration = GetConfigurationOrDefault(apiClientConfiguration);
-            OktaClientConfigurationValidator.Validate(Configuration);
-
-            logger = logger ?? NullLogger.Instance;
-
-            var defaultClient = DefaultHttpClient.Create(
-                Configuration.ConnectionTimeout,
-                Configuration.Proxy,
-                logger);
-
-            var requestExecutor = new DefaultRequestExecutor(Configuration, defaultClient, logger);
-            var resourceFactory = new ResourceFactory(this, logger, new AbstractResourceTypeResolverFactory(ResourceTypeHelper.AllDefinedTypes));
-            var userAgentBuilder = new UserAgentBuilder("okta-sdk-abstractions", typeof(BaseOktaClient).GetTypeInfo().Assembly.GetName().Version);
-
-            _dataStore = new DefaultDataStore(
-                requestExecutor,
-                new DefaultSerializer(),
-                resourceFactory,
-                logger,
-                userAgentBuilder);
-        }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="BaseOktaClient"/> class using the specified <see cref="HttpClient"/>.
         /// </summary>
         /// <param name="apiClientConfiguration">
@@ -75,16 +43,22 @@ namespace Okta.Sdk.Abstractions
         /// </param>
         /// <param name="httpClient">The HTTP client to use for requests to the Okta API.</param>
         /// <param name="logger">The logging interface to use, if any.</param>
-        public BaseOktaClient(OktaClientConfiguration apiClientConfiguration, HttpClient httpClient, ILogger logger = null)
+        public BaseOktaClient(OktaClientConfiguration apiClientConfiguration = null, HttpClient httpClient = null, ILogger logger = null, string userAgent = null)
         {
             Configuration = GetConfigurationOrDefault(apiClientConfiguration);
             OktaClientConfigurationValidator.Validate(Configuration);
 
             logger = logger ?? NullLogger.Instance;
 
+            httpClient = httpClient ?? DefaultHttpClient.Create(
+                Configuration.ConnectionTimeout,
+                Configuration.Proxy,
+                logger);
+
             var requestExecutor = new DefaultRequestExecutor(Configuration, httpClient, logger);
+
             var resourceFactory = new ResourceFactory(this, logger, new AbstractResourceTypeResolverFactory(ResourceTypeHelper.AllDefinedTypes));
-            var userAgentBuilder = new UserAgentBuilder("okta-sdk-abstractions", typeof(BaseOktaClient).GetTypeInfo().Assembly.GetName().Version);
+            var userAgentBuilder = new UserAgentBuilder(userAgent ?? "okta-sdk-abstractions", typeof(BaseOktaClient).GetTypeInfo().Assembly.GetName().Version);
 
             _dataStore = new DefaultDataStore(
                 requestExecutor,

--- a/Okta.Sdk.Abstractions/DefaultHttpClient.cs
+++ b/Okta.Sdk.Abstractions/DefaultHttpClient.cs
@@ -32,7 +32,7 @@ namespace Okta.Sdk.Abstractions
                 AllowAutoRedirect = false,
             };
 
-            if (proxyConfiguration != null)
+            if (proxyConfiguration != null && !string.IsNullOrEmpty(proxyConfiguration.Host))
             {
                 handler.Proxy = new DefaultProxy(proxyConfiguration, logger);
                 logger.LogInformation("Using proxy from configuration");


### PR DESCRIPTION
Simplify the constructors for BaseOktaClient and AuthenticationClient to reduce code duplication.  The only differences between the 4 implementations were:
1.  The way `httpClient` was handled if not specified.  I have converted the logic from the overload into a conditional if the argument is null.
2.  The way `AbstractResourceTypeResolverFactory` lists all types.  Following the code path of the 2 implementations I found they actually return the same thing, so I simplified it into a single way of calling it.
3.  The `userAgentBuilder` uses a different user agent in each client, so I added an optional parameter which allows it to be set, which defaults to the old generic `okta-sdk-abstractions` if null.  This allows the desired behavior without code duplication.

This is the last major change before we remove the beta label from the Auth SDK

[WIP] Still testing to ensure there's no issues with the Okta Management SDK in the future