### PR TITLE
OKTA-330325 Ensure primary authentication expiration is 5 minutes fro…

### DIFF
--- a/Okta.Auth.Sdk.UnitTests/AuthenticationClientShould.cs
+++ b/Okta.Auth.Sdk.UnitTests/AuthenticationClientShould.cs
@@ -212,6 +212,7 @@ namespace Okta.Auth.Sdk.UnitTests
             authResponse.AuthenticationStatus.Should().Be(AuthenticationStatus.Success);
             authResponse.SessionToken.Should().Be("00t6IUQiVbWpMLgtmwSjMFzqykb5QcaBNtveiWlGeM");
             authResponse.ExpiresAt.Value.Date.Should().Be(new DateTime(2015, 11, 3));
+            authResponse.ExpiresAt.Value.Should().Be(DateTimeOffset.Parse("2015-11-03T10:15:57.000Z"));
 
             var user = authResponse.Embedded.GetProperty<Resource>("user");
             user.Should().NotBeNull();

--- a/Okta.Sdk.Abstractions/DefaultSerializer.cs
+++ b/Okta.Sdk.Abstractions/DefaultSerializer.cs
@@ -31,7 +31,7 @@ namespace Okta.Sdk.Abstractions
                 DefaultValueHandling = DefaultValueHandling.Ignore,
                 ContractResolver = new DefaultContractResolver(),
                 DateParseHandling = DateParseHandling.DateTimeOffset,
-        };
+            };
 
             _serializer.Converters.Add(new RecursiveDictionaryConverter());
             _serializer.Converters.Add(new ResourceSerializingConverter());

--- a/Okta.Sdk.Abstractions/DefaultSerializer.cs
+++ b/Okta.Sdk.Abstractions/DefaultSerializer.cs
@@ -30,7 +30,8 @@ namespace Okta.Sdk.Abstractions
                 NullValueHandling = NullValueHandling.Ignore,
                 DefaultValueHandling = DefaultValueHandling.Ignore,
                 ContractResolver = new DefaultContractResolver(),
-            };
+                DateParseHandling = DateParseHandling.DateTimeOffset,
+        };
 
             _serializer.Converters.Add(new RecursiveDictionaryConverter());
             _serializer.Converters.Add(new ResourceSerializingConverter());


### PR DESCRIPTION
…m authentication

<!-- 
Before creating an issue or submitting a PR, please check that your issue is not already fixed in the latest stable version and that a similar issue or PR is not reported already (also check closed issues).
-->

<!--
Please help us process GitHub Issues faster by providing the following information.

Note: If you have a question about your entire application or use case, please post it on the Okta Developer Forum (https://devforum.okta.com) instead. For urgent issues contact support@okta.com. Issues in this repository are reserved for bug reports and feature requests.
-->


## Issue \#
<!-- Reference any existing issue(s) here. -->
https://oktainc.atlassian.net/browse/OKTA-330325
Fix #41 41

## Code
<!-- If possible, commit unit tests separately from the implementation to simplify validation. -->
- [x] Unit test(s)
- [x] Implementation


## Current behavior
<!-- Describe what behavior is changing, if any. -->
json date strings are being converted to DateTime objects, timezone information is lost during subsequent =>String=>DateTimeOffset conversion.

## Desired behavior
<!-- Describe what the desired behavior is. -->
json date strings will be deserialized to DateTimeOffset objects, timezone information is preserved during String=>DateTimeOffset conversion.

## Additional Context
<!-- Describe the motivation or the concrete use case. -->
