### PR TITLE
OKTA-506997: reference Okta.Sdk.Abstractions v4.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 Running changelog of releases since `2.0.1`
 
+## v2.0.6
+
+
+### Updates
+
+- Update NuGet reference to the latest Okta.Sdk.Abstractions v4.0.5
+
 ## v2.0.5
 
 

--- a/Okta.Auth.Sdk.UnitTests/Okta.Auth.Sdk.UnitTests.csproj
+++ b/Okta.Auth.Sdk.UnitTests/Okta.Auth.Sdk.UnitTests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="FluentAssertions" Version="6.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="NSubstitute" Version="4.3.0" />
-    <PackageReference Include="Okta.Sdk.Abstractions" Version="4.0.4" />
+    <PackageReference Include="Okta.Sdk.Abstractions" Version="4.0.5" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>

--- a/Okta.Auth.Sdk/Okta.Auth.Sdk.csproj
+++ b/Okta.Auth.Sdk/Okta.Auth.Sdk.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
-    <Version>2.0.5</Version>
+    <Version>2.0.6</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Okta.Auth.Sdk/Okta.Auth.Sdk.csproj
+++ b/Okta.Auth.Sdk/Okta.Auth.Sdk.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Okta.Sdk.Abstractions" Version="4.0.4" />
+    <PackageReference Include="Okta.Sdk.Abstractions" Version="4.0.5" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
Reference Okta.Sdk.Abstractions v4.0.5 which will set default authorization header if `Token` is specified in configuration, see https://github.com/okta/okta-sdk-abstractions-dotnet/pull/22