### PR TITLE
OKTA-514726: update Okta.Sdk.Abstractions reference to 4.0.6 which references Newtonsoft.Json 13.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: csharp
 mono: latest
-dotnet: 5.0
+dotnet: 6.0
 before_install:
   - sudo apt-get install dotnet-sdk-3.1
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 Running changelog of releases since `2.0.1`
 
+## v2.0.7
+
+
+### Updates
+
+- Update NuGet reference to the latest Okta.Sdk.Abstractions v4.0.6
+
 ## v2.0.6
 
 

--- a/Okta.Auth.Sdk.IntegrationTests/Okta.Auth.Sdk.IntegrationTests.csproj
+++ b/Okta.Auth.Sdk.IntegrationTests/Okta.Auth.Sdk.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Okta.Auth.Sdk.UnitTests/Okta.Auth.Sdk.UnitTests.csproj
+++ b/Okta.Auth.Sdk.UnitTests/Okta.Auth.Sdk.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -10,7 +10,7 @@
     <PackageReference Include="FluentAssertions" Version="6.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="NSubstitute" Version="4.3.0" />
-    <PackageReference Include="Okta.Sdk.Abstractions" Version="4.0.5" />
+    <PackageReference Include="Okta.Sdk.Abstractions" Version="4.0.6" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>

--- a/Okta.Auth.Sdk/Okta.Auth.Sdk.csproj
+++ b/Okta.Auth.Sdk/Okta.Auth.Sdk.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
-    <Version>2.0.6</Version>
+    <Version>2.0.7</Version>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Okta.Sdk.Abstractions" Version="4.0.5" />
+    <PackageReference Include="Okta.Sdk.Abstractions" Version="4.0.6" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
Update to Okta.Sdk.Abstractions should be published first: https://github.com/okta/okta-sdk-abstractions-dotnet/pull/24